### PR TITLE
Lager første versjon av RemixLink

### DIFF
--- a/app/components/RemixLink.tsx
+++ b/app/components/RemixLink.tsx
@@ -1,0 +1,60 @@
+import { useHref } from "@remix-run/react";
+import type { LinkProps } from "@remix-run/react";
+import React, { forwardRef } from "react";
+import type { Ref } from "react";
+import { useLinkClickHandler } from "react-router-dom";
+import { Button, Link } from "@navikt/ds-react";
+
+interface IProps extends LinkProps {
+  as: "Link" | "Button";
+  children: React.ReactElement | string;
+}
+
+export const RemixLink = forwardRef(RemixLinkComponent);
+
+function RemixLinkComponent(
+  { onClick, replace = false, state, target, to, as, children }: IProps,
+  ref: Ref<HTMLAnchorElement> | undefined
+) {
+  const href = useHref(to);
+  const handleClick = useLinkClickHandler(to, {
+    replace,
+    state,
+    target,
+  });
+
+  if (as === "Button") {
+    return (
+      <Button
+        href={href}
+        onClick={(event) => {
+          // @ts-ignore
+          onClick?.(event);
+          if (!event.defaultPrevented) {
+            // @ts-ignore
+            handleClick(event);
+          }
+        }}
+        ref={ref}
+        as="a"
+      >
+        {children}
+      </Button>
+    );
+  }
+
+  return (
+    <Link
+      href={href}
+      onClick={(event) => {
+        onClick?.(event);
+        if (!event.defaultPrevented) {
+          handleClick(event);
+        }
+      }}
+      ref={ref}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/app/routes/saksbehandling._index.tsx
+++ b/app/routes/saksbehandling._index.tsx
@@ -1,11 +1,12 @@
-import { Button, Table } from "@navikt/ds-react";
+import { Table } from "@navikt/ds-react";
 import { json } from "@remix-run/node";
 import type { MetaFunction } from "@remix-run/node";
 import type { LoaderArgs } from "@remix-run/node";
-import { Link, useLoaderData } from "@remix-run/react";
+import { useLoaderData } from "@remix-run/react";
 import { hentOppgaver } from "~/models/oppgave.server";
 import type { IOppgave } from "~/models/oppgave.server";
 import { hentFormattertDato } from "~/utils/dato.utils";
+import { RemixLink } from "../components/RemixLink";
 
 export async function loader({ params }: LoaderArgs) {
   const oppgaver = await hentOppgaver();
@@ -46,9 +47,9 @@ export default function Saksbehandling() {
                 <Table.DataCell>{hentFormattertDato(opprettet)}</Table.DataCell>
                 <Table.DataCell>{tilstand}</Table.DataCell>
                 <Table.DataCell>
-                  <Link to={`person/${person}/oppgave/${uuid}`}>
-                    <Button>Behandle</Button>
-                  </Link>
+                  <RemixLink to={`person/${person}/oppgave/${uuid}`} as="Button">
+                    Behandle
+                  </RemixLink>
                 </Table.DataCell>
               </Table.Row>
             );


### PR DESCRIPTION
I NextJS kunne vi gjøre slik for å få vise lenker som brukte designsystemets komponenter, enten `<Link>` eller `<Button as="a">`:

```
<Link href="#" passHref legacyBehavior> // Link fra Nextjs
  <Button as="a">Lenke</Button> // Button fra Aksel
</Link>

// Resultat:
<a href="en-url-her" class="aksels-button-klasser">Tekst her</a>
```

Dette fungerer ikke slik i Remix. Hvis man prøver seg på en lignende variant får man følgende resultat:
```
<Link to="en-url-her"> // Link fra Remix
  <Button as="a">Lenke</Button> // Button fra Aksel
</Link>

// Resultat
<a href="en-url-her">
  <a href="en-url-her" class="aksels-button-klasser">Tekst her</a>
</a>
```

Remix anbefaler at vi [lager vår egen komponent](https://github.com/remix-run/react-router/pull/7409) for å vise custom komponenter i lenker. Derfor RemixLink. Dermed denne komponenten, som bruker [useLinkClickHandler](https://reactrouter.com/en/main/hooks/use-link-click-handler), som anbefalt.

For å få en lenke som ser ut som en knapp, og som fungerer som en Remix Link, blir koden nå følgende:
```
<RemixLink to="en-url-her" as="Button">Tekst her</RemixLink>

// Resultat: 
<a href="en-url-her" class="aksels-button-klasser">Tekst her</a>
```