### PR TITLE
Legg til krav om medlemskap i saksbehandler/beslutter gruppe

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -59,10 +59,12 @@ spec:
         - application: dp-iverksett
   azure:
     application:
-      tenant: trygdeetaten.no
+      tenant: {{azure.tenant}}
       enabled: true
-      allowAllUsers: true
       claims:
+        groups:
+          - id: {{azure.grupper.saksbehandler}}
+          - id: {{azure.grupper.beslutter}}
         extra:
           - NAVident
     sidecar:

--- a/.nais/vars-dev.yaml
+++ b/.nais/vars-dev.yaml
@@ -3,3 +3,9 @@ base_path: "/saksbehandling"
 dp-behandling_url: "https://dp-behandling.intern.dev.nav.no"
 dp-behandling_host: "dp-behandling.intern.dev.nav.no"
 dp-rapportering_url: "http://dp-rapportering"
+
+azure:
+  tenant: trygdeetaten.no
+  grupper:
+    saksbehandler: "3e28466f-c53d-46da-8b44-a4abc2ad4593" # 0000-GA-Dagpenger-Saksbehandler
+    beslutter: "11b8475a-fb12-41aa-b1f6-8497c1b5385b" # 0000-GA-Dagpenger-Beslutter

--- a/.nais/vars-prod.yaml
+++ b/.nais/vars-prod.yaml
@@ -3,3 +3,9 @@ base_path: "/saksbehandling"
 dp-behandling_url: "https://dp-behandling.intern.nav.no"
 dp-behandling_host: "dp-behandling.intern.nav.no"
 dp-rapportering_url: "http://dp-rapportering"
+
+azure:
+  tenant: nav.no
+  grupper:
+    saksbehandler: "2e9c63d8-322e-4c1f-b500-a0abb812761c" # 0000-GA-Dagpenger-Saksbehandler
+    beslutter: "70d54cad-53a3-4788-bbe3-565096f01da7" # 0000-GA-Dagpenger-Beslutter


### PR DESCRIPTION
Dette skrur på enforcing av at brukeren må være medlem i gruppene. Det kan man ordne selv for IDA-brukere i IDA.