### PR TITLE
Feilhåndtering av SAF-kall uten at vi kaster en full error

### DIFF
--- a/app/models/SAF.server.ts
+++ b/app/models/SAF.server.ts
@@ -1,4 +1,4 @@
-import { logger } from "../../server/logger";
+import { logger, sikkerLogger } from "../../server/logger";
 import { v4 as uuidv4 } from "uuid";
 import { gql, GraphQLClient } from "graphql-request";
 import { getSaksbehandler, getSession } from "./auth.server";
@@ -68,6 +68,7 @@ export async function hentJournalpost(
   } catch (error: unknown) {
     logger.warn(`Feil fra SAF med call-id ${callId}: ${error}`);
     const errorMessage = error instanceof Error ? error.message : "Feil ved henting av dokumenter";
+    sikkerLogger.warn(`SAF kall catch error: ${error} - ${errorMessage}`);
 
     return {
       status: "error",

--- a/app/models/SAF.server.ts
+++ b/app/models/SAF.server.ts
@@ -4,6 +4,7 @@ import { gql, GraphQLClient } from "graphql-request";
 import { getSaksbehandler, getSession } from "./auth.server";
 import { getEnv } from "~/utils/env.utils";
 import { mockJournalpost } from "../../mock-data/mock-journalpost";
+import { type INetworkResponse } from "~/utils/types";
 
 export interface IJournalpost {
   journalpostId: string;
@@ -28,9 +29,12 @@ interface IJournalpostDokumentvariant {
 export async function hentJournalpost(
   request: Request,
   journalpostId: string,
-): Promise<IJournalpost> {
+): Promise<INetworkResponse<IJournalpost>> {
   if (getEnv("IS_LOCALHOST") === "true") {
-    return mockJournalpost;
+    return {
+      status: "success",
+      data: mockJournalpost,
+    };
   }
 
   const session = await getSession(request);
@@ -53,24 +57,25 @@ export async function hentJournalpost(
 
   try {
     logger.info(`Henter dokumenter med call-id: ${callId}`);
-    const data = await client.request(journalpostGrapqlQuery, { journalpostId });
+    const response = await client.request(journalpostGrapqlQuery, { journalpostId });
     // TODO Fiks typer på graphql
     // Graphql returnerer et object med property journalpost som inneholder en journalpost.
-    // @ts-ignore
-    return data.journalpost;
+    return {
+      status: "success",
+      // @ts-ignore
+      data: response.journalpost,
+    };
   } catch (error: unknown) {
     logger.warn(`Feil fra SAF med call-id ${callId}: ${error}`);
-    if (error instanceof Error) {
-      //todo: greie å lese errorobjektet som graphql error, eksempel:
-      //Error: tekst: {"response":{"errors":[{"message":"Tilgang til ressurs (journalpost/dokument) ble avvist.","extensions":{"code":"forbidden","classification":"ExecutionAborted"}}],"data":"xxx"}}
-      throw new Response(
-        `Feil ved henting av dokumenter, antakeligvis tilgangsproblemer. ${error.message}`,
-        {
-          status: 500,
-        },
-      );
-    }
-    throw new Response(`Feil ved henting av dokumenter.`, { status: 500 });
+    const errorMessage = error instanceof Error ? error.message : "Feil ved henting av dokumenter";
+
+    return {
+      status: "error",
+      error: {
+        statusCode: 500,
+        statusText: errorMessage,
+      },
+    };
   }
 }
 

--- a/app/routes/saksbehandling.oppgave.$oppgaveId.steg.$stegId.tsx
+++ b/app/routes/saksbehandling.oppgave.$oppgaveId.steg.$stegId.tsx
@@ -49,7 +49,7 @@ export interface Metadata {
 }
 
 export default function PersonBehandleVilkaar() {
-  const { oppgave, journalposter, journalpostError } = useTypedRouteLoaderData(
+  const { oppgave, journalposter } = useTypedRouteLoaderData(
     "routes/saksbehandling.oppgave.$oppgaveId",
   );
   const actionResponse = useActionData<typeof action>();
@@ -77,13 +77,13 @@ export default function PersonBehandleVilkaar() {
         )}
       </div>
 
-      {journalposter && journalposter.length > 0 && (
+      {journalposter && journalposter.data.length > 0 && (
         <div className={styles.dokumentContainer}>
-          <PDFLeser journalposter={journalposter} />
+          <PDFLeser journalposter={journalposter.data} />
         </div>
       )}
 
-      {journalpostError && (
+      {journalposter.errors && (
         <div className={styles.dokumentContainer}>
           <Alert variant="error" className="my-4">
             En feil oppsto når vi skulle hente ut dokumentene.

--- a/app/routes/saksbehandling.oppgave.$oppgaveId.steg.$stegId.tsx
+++ b/app/routes/saksbehandling.oppgave.$oppgaveId.steg.$stegId.tsx
@@ -49,7 +49,7 @@ export interface Metadata {
 }
 
 export default function PersonBehandleVilkaar() {
-  const { oppgave, journalposter } = useTypedRouteLoaderData(
+  const { oppgave, journalposter, journalpostError } = useTypedRouteLoaderData(
     "routes/saksbehandling.oppgave.$oppgaveId",
   );
   const actionResponse = useActionData<typeof action>();
@@ -80,6 +80,14 @@ export default function PersonBehandleVilkaar() {
       {journalposter && journalposter.length > 0 && (
         <div className={styles.dokumentContainer}>
           <PDFLeser journalposter={journalposter} />
+        </div>
+      )}
+
+      {journalpostError && (
+        <div className={styles.dokumentContainer}>
+          <Alert variant="error" className="my-4">
+            En feil oppsto når vi skulle hente ut dokumentene.
+          </Alert>
         </div>
       )}
     </div>

--- a/app/routes/saksbehandling.oppgave.$oppgaveId.tsx
+++ b/app/routes/saksbehandling.oppgave.$oppgaveId.tsx
@@ -28,10 +28,6 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   for (const journalpostId of oppgave.journalposter) {
     const response = await hentJournalpost(request, journalpostId);
 
-    if (response.status === "error") {
-      journalposter.errors = true;
-    }
-
     if (response.status === "success" && response.data) {
       journalposter.data.push(response.data);
     } else {

--- a/app/routes/saksbehandling.oppgave.$oppgaveId.tsx
+++ b/app/routes/saksbehandling.oppgave.$oppgaveId.tsx
@@ -16,13 +16,19 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const oppgave = await hentOppgave(params.oppgaveId, session);
 
   const journalposter: IJournalpost[] = [];
+  let journalpostError = false;
 
   for (const journalpostId of oppgave.journalposter) {
-    const data = await hentJournalpost(request, journalpostId);
-    journalposter.push(data);
+    const response = await hentJournalpost(request, journalpostId);
+
+    if (response.status === "success" && response.data) {
+      journalposter.push(response.data);
+    } else {
+      journalpostError = true;
+    }
   }
 
-  return json({ oppgave, journalposter });
+  return json({ oppgave, journalposter, journalpostError });
 }
 
 export default function PersonBehandle() {


### PR DESCRIPTION
I dag får vi full feilmelding på hele siden når SAF er nede/utilgjengelig for brukeren. Dette er ikke en kritisk feil for oss, dermed endrer jeg det til den nye typen `INetworkResponse`, og håndterer feilmeldingene i viewet i stedet.

Tar gjerne imot forslag hvis dere har andre måter å sette `journalpostError` på. Grunnen til at jeg satte det opp slik er at det sannsynligvis kan være en mellomstate mellom full feil og full success, der noen journalposter kan feile imens andre fungerer. Derfor må de to statene kunne vises samtidig.

Slik ser det ut i dag, dette vil jeg vekk fra:
![image](https://github.com/navikt/dp-saksbehandling-frontend/assets/3233286/9da9da36-ade6-4613-993c-8cd5ed2dcc68)

Slik vil det se ut fremover:
![image](https://github.com/navikt/dp-saksbehandling-frontend/assets/3233286/85e8fdb4-5d0c-47e8-b426-8536951639b7)
