### PR TITLE
Mulig fiks av mismatch mellom det som blir lastet opp i CDN og det so…

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -83,12 +83,11 @@ jobs:
           dockerfile: Dockerfile
           docker_context: .
 
-      - name: Build static files
-        uses: docker/build-push-action@v7
-        with:
-          target: build-export
-          outputs: type=local,dest=build
-          secrets: NODE_AUTH_TOKEN=${{ secrets.READER_TOKEN }}
+      - name: Extract static files from Docker image
+        run: |
+          docker create --name extract-build ${{ steps.docker-build-push.outputs.image }}
+          docker cp extract-build:/app/build/client ./build/client
+          docker rm extract-build
 
       - name: Upload static files
         uses: nais/deploy/actions/cdn-upload/v2@master


### PR DESCRIPTION
…m blir referert i HTML-sider

  Workflow-en kjørte to uavhengige Vite-byggjobber for samme commit:

   1. nais/docker-build-push → bygger Docker-imaget → pnpm build #1 → hashes ABC123
   2. docker/build-push-action (target: build-export) → bygger på nytt → pnpm build #2 → hashes DEF456

  HTML-en i Docker-imaget refererer til ABC123, men CDN inneholder DEF456. Nettleseren ber om filer som ikke finnes → blank side / 404 på assets.

  Vite-hashes er basert på filinnhold, men BuildKit er ikke deterministisk på tvers av separate docker build-kjøringer — timestamps, cache-state og byggemiljø kan påvirke output-hashes.