### PR TITLE
fix(logger): bruk korrekt ECS-format for OpenSearch

### DIFF
--- a/app/utils/logger.utils.test.ts
+++ b/app/utils/logger.utils.test.ts
@@ -1,0 +1,91 @@
+import { Writable } from "node:stream";
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createLogger } from "./logger.utils";
+
+// Simulerer prod-miljø (ikke localhost)
+vi.stubEnv("IS_LOCALHOST", "false");
+
+function lagTestLogger() {
+  const linjer: string[] = [];
+  const destination = new Writable({
+    write(chunk, _encoding, callback) {
+      linjer.push(chunk.toString().trim());
+      callback();
+    },
+  });
+  const logger = createLogger(destination);
+  return { logger, linjer };
+}
+
+function parseLogg(linjer: string[]): Record<string, unknown> {
+  return JSON.parse(linjer[0]);
+}
+
+describe("logger.utils — ECS-format (prod)", () => {
+  beforeEach(() => {
+    vi.stubEnv("IS_LOCALHOST", "false");
+  });
+
+  test("info-logg har log.level og @timestamp", () => {
+    const { logger, linjer } = lagTestLogger();
+    logger.info("testmelding");
+
+    const logg = parseLogg(linjer);
+    expect(logg["level"]).toBe("info");
+    expect(logg["@timestamp"]).toBeDefined();
+    expect(logg["message"]).toBe("testmelding");
+  });
+
+  test("error-logg har log.level error", () => {
+    const { logger, linjer } = lagTestLogger();
+    logger.error("noe gikk galt");
+
+    const logg = parseLogg(linjer);
+    expect(logg["level"]).toBe("error");
+    expect(logg["message"]).toBe("noe gikk galt");
+  });
+
+  test("warn-logg har log.level warn", () => {
+    const { logger, linjer } = lagTestLogger();
+    logger.warn("advarsel");
+
+    const logg = parseLogg(linjer);
+    expect(logg["level"]).toBe("warn");
+    expect(logg["message"]).toBe("advarsel");
+  });
+
+  test("logg med objekt flater ut felter korrekt", () => {
+    const { logger, linjer } = lagTestLogger();
+    logger.warn({ status: 404, message: "Not Found" });
+
+    const logg = parseLogg(linjer);
+    expect(logg["level"]).toBe("warn");
+    expect(logg["status"]).toBe(404);
+  });
+
+  test("logg inneholder @version: 1", () => {
+    const { logger, linjer } = lagTestLogger();
+    logger.info("versjonssjekk");
+
+    const logg = parseLogg(linjer);
+    expect(logg["@version"]).toBe("1");
+  });
+
+  test("logg inneholder ikke fnr eller PII-feltnavn", () => {
+    const { logger, linjer } = lagTestLogger();
+    logger.info("Henter sak for bruker");
+
+    const logg = parseLogg(linjer);
+    expect(Object.keys(logg)).not.toContain("fnr");
+    expect(Object.keys(logg)).not.toContain("fodselsnummer");
+  });
+
+  test("logg er gyldig JSON", () => {
+    const { logger, linjer } = lagTestLogger();
+    logger.info("json-sjekk");
+
+    expect(() => JSON.parse(linjer[0])).not.toThrow();
+  });
+});

--- a/app/utils/logger.utils.ts
+++ b/app/utils/logger.utils.ts
@@ -1,5 +1,5 @@
 import { ecsFormat } from "@elastic/ecs-pino-format";
-import type { Logger, LoggerOptions } from "pino";
+import type { DestinationStream, Logger, LoggerOptions } from "pino";
 import { pino } from "pino";
 
 import { getEnv } from "~/utils/env.utils";
@@ -15,35 +15,40 @@ const devConfig: LoggerOptions = {
 
 const prodConfig: LoggerOptions = {
   ...ecsFormat(),
-  timestamp: false,
+  mixin: () => ({ "@version": "1" }),
   formatters: {
     level: (label) => ({ level: label }),
   },
 };
 
-const pinoLogger: Logger = pino(getEnv("IS_LOCALHOST") === "true" ? devConfig : prodConfig);
+export function createLogger(destination?: DestinationStream) {
+  const options = getEnv("IS_LOCALHOST") === "true" ? devConfig : prodConfig;
+  const pinoLogger: Logger = destination ? pino(options, destination) : pino(options);
+
+  return {
+    info: (data: unknown) => {
+      if (typeof document === "undefined") {
+        pinoLogger.info(data);
+      } else {
+        console.log(data);
+      }
+    },
+    error: (data: unknown) => {
+      if (typeof document === "undefined") {
+        pinoLogger.error(data);
+      } else {
+        console.error(data);
+      }
+    },
+    warn: (data: unknown) => {
+      if (typeof document === "undefined") {
+        pinoLogger.warn(data);
+      } else {
+        console.warn(data);
+      }
+    },
+  };
+}
 
 // Logger wrapper to handle server-side and client-side logging. Console.log is needed client-side for faro auto capture to function properly
-export const logger = {
-  info: (data: unknown) => {
-    if (typeof document === "undefined") {
-      pinoLogger.info(data);
-    } else {
-      console.log(data);
-    }
-  },
-  error: (data: unknown) => {
-    if (typeof document === "undefined") {
-      pinoLogger.error(data);
-    } else {
-      console.error(data);
-    }
-  },
-  warn: (data: unknown) => {
-    if (typeof document === "undefined") {
-      pinoLogger.warn(data);
-    } else {
-      console.warn(data);
-    }
-  },
-};
+export const logger = createLogger();


### PR DESCRIPTION
- Legg til formatters.level for å bruke "level" i stedet for "log.level"
- Legg til "@version": "1" via mixin
- Refaktorer til createLogger(destination?) for testbarhet