### PR TITLE
fix(regelsett): inkluder saksbehandlingsregler i regelsett-oppslag   …

### DIFF
--- a/app/routes/oppgave.$oppgaveId.dagpenger-rett.$behandlingId._person.regelsett.$regelsettId.opplysning.$opplysningId.tsx
+++ b/app/routes/oppgave.$oppgaveId.dagpenger-rett.$behandlingId._person.regelsett.$regelsettId.opplysning.$opplysningId.tsx
@@ -11,6 +11,7 @@ import { useHandleAlertMessages } from "~/hooks/useHandleAlertMessages";
 import { useTypedRouteLoaderData } from "~/hooks/useTypedRouteLoaderData";
 import { useTypeSafeParams } from "~/hooks/useTypeSafeParams";
 import { handleActions } from "~/server-side-actions/handle-actions";
+import { alleRegelsett } from "~/utils/behandling.utils";
 import { isAlert } from "~/utils/type-guards";
 
 import { components } from "../../openapi/behandling-typer";
@@ -29,9 +30,7 @@ export default function Opplysning() {
   const actionData = useActionData<typeof action>();
   useHandleAlertMessages(isAlert(actionData) ? actionData : undefined);
 
-  const regelsett = [...behandling.vilkår, ...behandling.fastsettelser].find(
-    (sett) => sett.id === regelsettId,
-  );
+  const regelsett = alleRegelsett(behandling).find((sett) => sett.id === regelsettId);
 
   const opplysning = behandling.opplysninger.find(
     (opplysning) => opplysning.opplysningTypeId === opplysningId,

--- a/app/routes/oppgave.$oppgaveId.dagpenger-rett.$behandlingId._person.regelsett.$regelsettId.tsx
+++ b/app/routes/oppgave.$oppgaveId.dagpenger-rett.$behandlingId._person.regelsett.$regelsettId.tsx
@@ -2,6 +2,7 @@ import { type LoaderFunctionArgs, Outlet, redirect } from "react-router";
 import invariant from "tiny-invariant";
 
 import { hentBehandling } from "~/models/behandling.server";
+import { alleRegelsett } from "~/utils/behandling.utils";
 
 // Denne er kun for å redirecte til første opplysning i regelsettet. Avklaringer har kun id til hvilket regelsett den gjelder, men vi viser aldri kun regelsett uten opplysning. Vi må derfor redirecte
 export async function loader({ params, request }: LoaderFunctionArgs) {
@@ -15,9 +16,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   }
 
   const behandling = await hentBehandling(request, params.behandlingId);
-  const regelsett = [...behandling.vilkår, ...behandling.fastsettelser].find(
-    (sett) => sett.id === params.regelsettId,
-  );
+  const regelsett = alleRegelsett(behandling).find((sett) => sett.id === params.regelsettId);
 
   if (!regelsett) {
     throw new Response(`Finner ikke regelsett med navn ${params.regelsettNavn}`, { status: 404 });

--- a/app/utils/behandling.utils.ts
+++ b/app/utils/behandling.utils.ts
@@ -3,6 +3,19 @@ import { isDefined } from "~/utils/type-guards";
 
 import { components } from "../../openapi/behandling-typer";
 
+export function alleRegelsett(
+  behandling: Pick<
+    components["schemas"]["Behandling"],
+    "vilkår" | "fastsettelser" | "saksbehandlingsregler"
+  >,
+): components["schemas"]["Regelsett"][] {
+  return [
+    ...behandling.vilkår,
+    ...behandling.fastsettelser,
+    ...(behandling.saksbehandlingsregler ?? []),
+  ];
+}
+
 export function skalViseRegelsett(
   regelsett: components["schemas"]["Regelsett"],
   opplysninger: components["schemas"]["RedigerbareOpplysninger"][],


### PR DESCRIPTION
…                                                                                LSPs are disabled

Regelsett-lookupen i loader og komponent søkte kun i vilkår og fastsettelser. Dette førte til 404 når en avklaring lenket til et saksbehandlingsregelsett.

Laget en funskjon for å hente alle regelsettene.